### PR TITLE
fix up examples and reword slightly where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ conceptual object which exists in the real world.
 ## Entities within a stock management system
 
 Within our simple stock management system, we currently have four entity types.
-The relationships among our entities are defined as shown below:
+The relationships between our entities are defined as shown below:
 
 ![](https://fiware.github.io/tutorials.Entity-Relationships/img/entities.png)
 
@@ -103,7 +103,7 @@ The relationships among our entities are defined as shown below:
     -   Shelf count, i.e. number of items available on the shelf
 
 As you can see, each of the entities defined above contain some properties which
-are liable to change. For example, product price may change, stock may be sold
+are liable to change. For example, product price could change, stock could be sold
 and the number of items on the shelves would drop.
 
 # Architecture
@@ -255,9 +255,9 @@ is unspecified, the `/v2/entities` endpoint is used.
 Once an `<entity-id>` is known within the context, individual data entities can
 be manipulated using the `/v2/entities/<entity-id>` endpoint.
 
-It is recommended that entity identifiers should be URN's following the
+It is recommended that entity identifiers should be URNs following the
 [NGSI-LD guidelines](https://docbox.etsi.org/ISG/CIM/Open/ISG_CIM_NGSI-LD_API_Draft_for_public_review.pdf),
-therefore each `id` as a URN follows a standard format:
+therefore each `id` is a URN which follows a standard format:
 `urn:ngsi-ld:<entity-type>:<entity-id>`. This helps making every `id` in the
 context data unique.
 
@@ -318,7 +318,7 @@ previous tutorial.
 All examples refer to the **Product** entity as defined in the stock management
 system. CRUD operations will therefore relate to adding, reading, amending and
 deleting a product or series of products. This is a typical use case for a
-store regional manager, for example specifying prices and deciding what
+store regional manager, for example setting prices and deciding what
 products can be sold. The actual responses you receive in each case will depend
 on the state of the context data in your system at the time. If you find that
 you have already deleted an entity by mistake, you can restore the initial
@@ -639,7 +639,7 @@ curl -X GET \
 
 ### Response:
 
-On start up the context held nine products, three more have been added by
+On start-up the context held nine products, three more have been added by
 create operations so the full context will now contain twelve products.
 
 ```json
@@ -747,7 +747,7 @@ curl -X GET \
 
 #### Response:
 
-On start up the context held nine products, three more have been added by
+On start-up the context held nine products, three more have been added by
 create operations so the full context will now contain twelve products.
 
 ```json
@@ -845,7 +845,7 @@ curl -X GET \
 
 #### Response:
 
-On start up the context held nine products, three more have been added by
+On start-up the context held nine products, three more have been added by
 create operations so the full context will now contain twelve products.
 
 ```json
@@ -911,12 +911,12 @@ of the given `type`.
 Overwrite operations are mapped to HTTP PUT. HTTP PATCH can be used to update
 several attributes at once.
 
--   The `/v2/entities/<entity>/attrs/<attribute>/value` endpoint can be used to
+-   The `/v2/entities/<entity>/attrs/<attribute>/value` endpoint is used to
     update an attribute
--   The `/v2/entities/<entity>/attrs` endpoint can be used to update multiple
+-   The `/v2/entities/<entity>/attrs` endpoint is used to update multiple
     attributes
 
-### Overwrite an Attribute's value
+### Overwrite the value of an Attribute value
 
 This example updates the value of the price attribute of the Entity with
 `id=urn:ngsi-ld:Product:001`

--- a/README.md
+++ b/README.md
@@ -68,64 +68,64 @@ available as
 # Data Entities
 
 Within the FIWARE platform, an entity represents the state of a physical or
-conceptural object which exists in the real world.
+conceptual object which exists in the real world.
 
 ## Entities within a stock management system
 
-Within our simple stock management system, currently have four types of entity.
-The relationship between our entities is defined as shown:
+Within our simple stock management system, we currently have four entity types.
+The relationships among our entities are defined as shown below:
 
 ![](https://fiware.github.io/tutorials.Entity-Relationships/img/entities.png)
 
 -   A **Store** is a real world bricks and mortar building. Stores would have
     properties such as:
-    -   A name of the store e.g. "Checkpoint Markt"
-    -   An address "Friedrichstraße 44, 10969 Kreuzberg, Berlin"
-    -   A phyiscal location e.g. _52.5075 N, 13.3903 E_
--   A **Shelf** is a real world device to hold objects which we wish to sell.
+    -   Store name, e.g. "Checkpoint Markt"
+    -   Address, e.g. "Friedrichstraße 44, 10969 Kreuzberg, Berlin"
+    -   Physical location, e.g. _52.5075 N, 13.3903 E_
+-   A **Shelf** is a real world object to hold items which we wish to sell.
     Each shelf would have properties such as:
-    -   A name of the shelf e.g. "Wall Unit"
-    -   A phyiscal location e.g. _52.5075 N, 13.3903 E_
-    -   A maximum capacity
-    -   An association to the store in which the shelf is present
--   A **Product** is defined as something that we sell - it is conceptural
+    -   Shelf name, e.g. "Wall Unit"
+    -   Physical location, e.g. _52.5075 N, 13.3903 E_
+    -   Maximum capacity
+    -   An association to the store in which the shelf is located
+-   A **Product** is defined as something that we sell - it is a conceptual
     object. Products would have properties such as:
-    -   A name of the product e.g. "Vodka"
-    -   A price e.g. 13.99 Euros
-    -   A size e.g. Small
--   An **Inventory Item** is another conceptural entity, used to assocate
+    -   Product name, e.g. "Vodka"
+    -   Price, e.g. 13.99 Euros
+    -   Size, e.g. Small
+-   An **Inventory Item** is another conceptual entity, used to associate
     products, stores, shelves and physical objects. It would have properties
     such as:
     -   An association to the product being sold
     -   An association to the store in which the product is being sold
     -   An association to the shelf where the product is being displayed
-    -   A stock count of the quantity of the product available in the warehouse
-    -   A stock count of the quantity of the product available on the shelf
+    -   Stock count, i.e. product quantity available in the warehouse
+    -   Shelf count, i.e. number of items available on the shelf
 
 As you can see, each of the entities defined above contain some properties which
-are liable to change. A product could change its price, stock could be sold and
-the shelf count of stock could be reduced and so on.
+are liable to change. For example, product price may change, stock may be sold
+and the number of items on the shelves would drop.
 
 # Architecture
 
 This application will only make use of one FIWARE component - the
-[Orion Context Broker](https://fiware-orion.readthedocs.io/en/latest/). Usage of
+[Orion Context Broker](https://fiware-orion.readthedocs.io/en/latest/). Using
 the Orion Context Broker is sufficient for an application to qualify as
 _“Powered by FIWARE”_.
 
 Currently, the Orion Context Broker relies on open source
-[MongoDB](https://www.mongodb.com/) technology to keep persistence of the
-context data it holds. Therefore, the architecture will consist of two elements:
+[MongoDB](https://www.mongodb.com/) technology to store the context data it
+manages. Therefore, the architecture will consist of two components:
 
 -   The [Orion Context Broker](https://fiware-orion.readthedocs.io/en/latest/)
     which will receive requests using
     [NGSI](https://fiware.github.io/specifications/OpenAPI/ngsiv2)
--   The underlying [MongoDB](https://www.mongodb.com/) database :
-    -   Used by the Orion Context Broker to hold context data information such
+-   The underlying [MongoDB](https://www.mongodb.com/) database:
+    -   Used by the Orion Context Broker to store context information such
         as data entities, subscriptions and registrations
 
-Since all interactions between the two elements are initiated by HTTP requests,
-the entities can be containerized and run from exposed ports.
+Since the two components interact by means of HTTP requests, they can be
+containerized and run from exposed ports.
 
 ![](https://fiware.github.io/tutorials.CRUD-Operations/img/architecture.png)
 
@@ -162,11 +162,12 @@ mongo-db:
     command: --bind_ip_all --smallfiles
 ```
 
-Both containers are residing on the same network - the Orion Context Broker is
-listening on Port `1026` and MongoDB is listening on the default port `271071`.
-Both containers are also exposing the same ports externally - this is purely for
-the tutorial access - so that cUrl or Postman can access them without being part
-of the same network. The command-line initialization should be self explanatory.
+Both containers reside on the same network - the Orion Context Broker is
+listening on port `1026` and MongoDB is listening on the default port `271071`.
+For the sake of this tutorial, we have also made the two ports available from
+outside the network so that cUrl or Postman can access them without having to
+be run from inside the network. The command-line initialization should be self
+explanatory.
 
 # Prerequisites
 
@@ -174,7 +175,7 @@ of the same network. The command-line initialization should be self explanatory.
 
 To keep things simple both components will be run using
 [Docker](https://www.docker.com). **Docker** is a container technology which
-allows to different components isolated into their respective environments.
+allows to package each component with its environment and run it in isolation.
 
 -   To install Docker on Windows follow the instructions
     [here](https://docs.docker.com/docker-for-windows/)
@@ -187,7 +188,7 @@ allows to different components isolated into their respective environments.
 applications. A
 [YAML file](https://raw.githubusercontent.com/Fiware/tutorials.Entity-Relationships/master/docker-compose.yml)
 is used configure the required services for the application. This means all
-container services can be brought up in a single command. Docker Compose is
+container services can be brought up with a single command. Docker Compose is
 installed by default as part of Docker for Windows and Docker for Mac, however
 Linux users will need to follow the instructions found
 [here](https://docs.docker.com/compose/install/)
@@ -213,7 +214,7 @@ functionality similar to a Linux distribution on Windows.
 
 All services can be initialised from the command-line by running the bash script
 provided within the repository. Please clone the repository and create the
-necessary images by running the commands as shown:
+necessary images by running the commands as shown below:
 
 ```console
 git clone git@github.com:Fiware/tutorials.CRUD-Operations.git
@@ -238,9 +239,9 @@ on startup.
 **Create**, **Read**, **Update** and **Delete** are the four basic functions of
 persistent storage. These operations are usually referred to using the acronym
 **CRUD**. Within a database each of these operations map directly to a series of
-commands, however the relationship with a RESTful API is slightly more complex.
+commands, however their relationship with a RESTful API is slightly more complex.
 
-The [Orion Context Broker](https://fiware-orion.readthedocs.io/en/latest/)uses
+The [Orion Context Broker](https://fiware-orion.readthedocs.io/en/latest/) uses
 [NGSI](https://fiware.github.io/specifications/OpenAPI/ngsiv2) to manipulate the
 context data. As a RESTful API, requests to manipulate the data held within the
 context follow the standard conventions found when mapping HTTP verbs to CRUD
@@ -254,11 +255,11 @@ is unspecified, the `/v2/entities` endpoint is used.
 Once an `<entity-id>` is known within the context, individual data entities can
 be manipulated using the `/v2/entities/<entity-id>` endpoint.
 
-It is recommended that entity identifiers should be a URN following
+It is recommended that entity identifiers should be URN's following the
 [NGSI-LD guidelines](https://docbox.etsi.org/ISG/CIM/Open/ISG_CIM_NGSI-LD_API_Draft_for_public_review.pdf),
-therefore each `id` is a URN follows a standard format:
-`urn:ngsi-ld:<entity-type>:<entity-id>`. This will mean that every `id` in the
-context data will be unique.
+therefore each `id` as a URN follows a standard format:
+`urn:ngsi-ld:<entity-type>:<entity-id>`. This helps making every `id` in the
+context data unique.
 
 | HTTP Verb  |                                               `/v2/entities`                                               |                                              `/v2/entities/<entity-id>`                                              |
 | ---------- | :--------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------: |
@@ -268,7 +269,7 @@ context data will be unique.
 | **PATCH**  |                                                    :x:                                                     |                                                         :x:                                                          |
 | **DELETE** |                                                    :x:                                                     |                                          DELETE an entity from the context                                           |
 
-A complete list of entity endpoints can be found by looking at the
+A complete list of entity endpoints can be found in the
 [NGSI v2 Swagger Specification](https://fiware.github.io/specifications/OpenAPI/ngsiv2#/Entities)
 
 ## Attribute CRUD Operations
@@ -293,20 +294,20 @@ There are three endpoints:
 | **PATCH**   | UPDATE one or more existing attributes from an existing entity. |                          :x:                          |                                           :x:                                            |
 | **DELETE**. |                               :x:                               | DELETE an existing attribute from an existing entity. |                                           :x:                                            |
 
-A complete list of attribute endpoints can be found by looking at the
+A complete list of attribute endpoints can be found in the
 [NGSI v2 Swagger Specification](https://fiware.github.io/specifications/OpenAPI/ngsiv2#/Attributes)
 
 ## Batch CRUD Operations
 
-Additionally the Orion Context Broker a convenience batch operation endpoint
+Additionally the Orion Context Broker has a convenience batch operation endpoint
 `/v2/op/update` to manipulate multiple entities in a single operation.
 
-Batch operations are always made using a POST request, where the payload is an
+Batch operations are always triggered by a POST request where the payload is an
 object with two properties:
 
 -   `actionType` specifies the kind of action to invoke (e.g. `delete`)
--   `entities` is an array object holding the list of entities to update, along
-    with the relevant entity data used to make the operation.
+-   `entities` is an array of objects holding the list of entities to update, along
+    with the relevant entity data used to perform the operation.
 
 # Example CRUD Operations using FIWARE
 
@@ -317,7 +318,7 @@ previous tutorial.
 All examples refer to the **Product** entity as defined in the stock management
 system. CRUD operations will therefore relate to adding, reading, amending and
 deleting a product or series of products. This is a typical use case for a
-regional manager of store for example - setting prices and deciding what
+store regional manager, for example specifying prices and deciding what
 products can be sold. The actual responses you receive in each case will depend
 on the state of the context data in your system at the time. If you find that
 you have already deleted an entity by mistake, you can restore the initial
@@ -332,14 +333,14 @@ context by reloading the data from the command-line
 Create Operations map to HTTP POST.
 
 -   The `/v2/entities` endpoint is used for creating new entities
--   The `/v2/entities/<entity>` endpoint is used adding new attributes
+-   The `/v2/entities/<entity>` endpoint is used for adding new attributes
 
-Any newly created entity must have a `id` and `type` attributes, each additional
-attributes are optional and will depend on the system being described. Each
-additional attribute should also have a defined `type` and a `value` attribute.
+Any newly created entity must have `id` and `type` attributes, other attributes
+are optional and will depend on the system being modelled. If additional
+attributes are present though, each should specify both a `type` and a `value`.
 
 The response will be **204 - No Content** if the operation is successful or
-**422 - Unprocessable Entity** error response if the operation fails
+**422 - Unprocessable Entity** if the operation fails.
 
 ### Create a New Data Entity
 
@@ -413,8 +414,8 @@ curl -X GET \
   --url 'http://localhost:1026/v2/entities/urn:ngsi-ld:Product:001?type=Product'
 ```
 
-As you can see there is now boolean `specialOffer` flag attached to the "Beer"
-**Product** entity
+As you can see there is now a boolean `specialOffer` flag attached to the "Beer"
+**Product** entity.
 
 ### Batch Create New Data Entities or Attributes
 
@@ -455,21 +456,21 @@ The request will fail if any of the attributes already exist in the context.
 Batch processing uses the `/v2/op/update` endpoint with a payload with two
 attributes
 
--   `actionType=append_strict` means that the request only succeed all entities
+-   `actionType=append_strict` means that the request only succeeds if all entities
     / attributes are new.
 -   The `entities` attribute holds an array of entities we wish to create.
 
-Subsequent request using the same data with the `actionType=append_strict` batch
+Subsequent requests using the same data with the `actionType=append_strict` batch
 operation will result in an error response.
 
 ### Batch Create/Overwrite New Data Entities
 
-This example uses the convenience batch processing endpoint to adds or amend two
+This example uses the convenience batch processing endpoint to add or amend two
 **Product** entities and one attribute (`offerPrice`) to the context.
 
--   if the entities already exist - the request will update the attributes of an
-    entity.
--   if the entities do not exist, a new entity will be created.
+-   if an entity already exists, the request will update that entity's
+    attributes.
+-   if an entity does not exist, a new entity will be created.
 
 #### :six: Request:
 
@@ -503,21 +504,20 @@ attributes:
 -   The entities attribute holds an array of entities we wish to
     create/overwrite.
 
-A Subsequent request using the same data with the `actionType=append` batch
-operation can applied without changing the result beyond the initial
-application.
+A subsequent request containing the same data (i.e. same entities and `actionType=append`)
+won't change the context state.
 
 ## Read Operations
 
--   The `/v2/entities` endpoint is used for listing operations
+-   The `/v2/entities` endpoint is used for listing entities
 -   The `/v2/entities/<entity>` endpoint is used for retrieving the details of a
     single entity
 
 ### Filtering
 
--   The options parameter (combined with the attrs parameter) is used to filter
-    the fields returned
--   The q parameter can be used to filter the entities returned
+-   The options parameter (combined with the attrs parameter) can be used to filter
+    the returned fields
+-   The q parameter can be used to filter the returned entities
 
 ### Read a Data Entity (verbose)
 
@@ -533,8 +533,8 @@ curl -X GET \
 
 #### Response:
 
-Product `urn:ngsi-ld:Product:010` is "Lemonade" at 99 cents. The response is as
-shown:
+Product `urn:ngsi-ld:Product:010` is "Lemonade" at 99 cents. The response is
+shown below:
 
 ```json
 {
@@ -563,8 +563,8 @@ curl -X GET \
 
 #### Response:
 
-Product `urn:ngsi-ld:Product:001` is "Beer" at 99 cents. The response is as
-shown:
+Product `urn:ngsi-ld:Product:001` is "Beer" at 99 cents. The response is
+shown below:
 
 ```json
 "Beer"
@@ -575,8 +575,8 @@ Context data can be retrieved by making a GET request to the
 
 ### Read a Data Entity (key-value pairs)
 
-This example reads the key-value pairs for two requested attributes (`name` and
-`price`) from the context of existing **Product** entity with a known `id`.
+This example reads the key-value pairs of two attributes (`name` and
+`price`) from the context of existing **Product** entities with a known `id`.
 
 #### :nine: Request:
 
@@ -587,8 +587,8 @@ curl -X GET \
 
 #### Response:
 
-Product `urn:ngsi-ld:Product:001` is "Beer" at 99 cents. The response is as
-shown:
+Product `urn:ngsi-ld:Product:001` is "Beer" at 99 cents. The response is
+shown below:
 
 ```json
 {
@@ -599,13 +599,13 @@ shown:
 }
 ```
 
-Combine the `options=keyValues` parameter and the `attrs` parameter to obtain
+Combine the `options=keyValues` parameter with the `attrs` parameter to retrieve
 key-value pairs.
 
 ### Read Multiple attributes values from a Data Entity
 
-This example reads the value of two requested attributes (`name` and `price`)
-from the context of existing **Product** entity with a known ID.
+This example reads the value of two attributes (`name` and `price`)
+from the context of existing **Product** entities with a known ID.
 
 #### :one::zero: Request:
 
@@ -616,15 +616,15 @@ curl -X GET \
 
 #### Response:
 
-Product `urn:ngsi-ld:Product:001` is "Beer" at 99 cents. The response is as
-shown:
+Product `urn:ngsi-ld:Product:001` is "Beer" at 99 cents. The response is
+shown below:
 
 ```json
 ["Beer", 99]
 ```
 
 Combine the `options=values` parameter and the `attrs` parameter to return a
-list of values in an array
+list of values in an array.
 
 ### List all Data Entities (verbose)
 
@@ -639,8 +639,8 @@ curl -X GET \
 
 ### Response:
 
-On Start up the context held nine products, three more have been added by the
-create operations so the full context will return twelve products.
+On start up the context held nine products, three more have been added by
+create operations so the full context will now contain twelve products.
 
 ```json
 [
@@ -747,8 +747,8 @@ curl -X GET \
 
 #### Response:
 
-On Start up the context held nine products, three more have been added by the
-create operations so the full context will return twelve products.
+On start up the context held nine products, three more have been added by
+create operations so the full context will now contain twelve products.
 
 ```json
 [
@@ -829,8 +829,8 @@ create operations so the full context will return twelve products.
 
 Full context data for a specified entity type can be retrieved by making a GET
 request to the `/v2/entities` endpoint and supplying the `type` parameter,
-combine this with the o`ptions=keyValues` parameter and the `attrs` parameter to
-obtain key-values.
+combine this with the `options=keyValues` parameter and the `attrs` parameter to
+retrieve key-values.
 
 ### List Data Entity by ID
 
@@ -845,8 +845,8 @@ curl -X GET \
 
 #### Response:
 
-On Start up the context held nine products, three more have been added by the
-create operations so the full context will return twelve products.
+On start up the context held nine products, three more have been added by
+create operations so the full context will now contain twelve products.
 
 ```json
 [
@@ -904,19 +904,19 @@ create operations so the full context will return twelve products.
 Context data for a specified entity type can be retrieved by making a GET
 request to the `/v2/entities` endpoint and supplying the `type` parameter.
 Combine this with `options=count` and `attrs=id` to return the `id` attributes
-of the given `type`
+of the given `type`.
 
 ## Update Operations
 
 Overwrite operations are mapped to HTTP PUT. HTTP PATCH can be used to update
 several attributes at once.
 
--   The `/v2/entities/<entity>/attrs/<attribute>/value` endpoint is used to
+-   The `/v2/entities/<entity>/attrs/<attribute>/value` endpoint can be used to
     update an attribute
--   The `/v2/entities/<entity>/attrs` endpoint is used to update multiple
+-   The `/v2/entities/<entity>/attrs` endpoint can be used to update multiple
     attributes
 
-### Overwrite the value of an Attribute value
+### Overwrite an Attribute's value
 
 This example updates the value of the price attribute of the Entity with
 `id=urn:ngsi-ld:Product:001`
@@ -936,7 +936,7 @@ Existing attribute values can be altered by making a PUT request to the
 ### Overwrite Multiple Attributes of a Data Entity
 
 This example simultaneously updates the values of both the price and name
-attributes of the Entity with `id=urn:ngsi-ld:Product:001`
+attributes of the Entity with `id=urn:ngsi-ld:Product:001`.
 
 #### :one::five: Request:
 
@@ -945,14 +945,15 @@ curl -iX PATCH \
   --url 'http://localhost:1026/v2/entities/urn:ngsi-ld:Product:001/attrs' \
   --header 'Content-Type: application/json' \
   --data ' {
-      "price":{"type":"Integer", "value": 89}
+      "price":{"type":"Integer", "value": 89},
+      "name": {"type":"Text", "value": "Ale"}
 }'
 ```
 
 ### Batch Overwrite Attributes of Multiple Data Entities
 
-This example uses the convenience batch processing endpoint to create a series
-of available products.
+This example uses the convenience batch processing endpoint to update existing
+products.
 
 #### :one::six: Request:
 
@@ -983,8 +984,8 @@ to update.
 
 ### Batch Create/Overwrite Attributes of Multiple Data Entities
 
-This example uses the convenience batch processing endpoint to create a series
-of available products.
+This example uses the convenience batch processing endpoint to update
+existing products.
 
 #### :one::seven: Request:
 
@@ -1015,8 +1016,8 @@ to update.
 
 ### Batch Replace Entity Data
 
-This example uses the convenience batch processing endpoint to create a series
-of available products.
+This example uses the convenience batch processing endpoint to replace entity
+data of existing products.
 
 #### :one::eight: Request:
 
@@ -1037,19 +1038,19 @@ curl -iX POST \
 
 Batch processing uses the `/v2/op/update` endpoint with a payload with two
 attributes - `actionType=replace` means we will overwrite existing entities if
-they exist whereas the `entities` attribute holds an array of entities we wish
-to update.
+they exist whereas the `entities` attribute holds an array of entities whose
+data we wish to replace.
 
 ## Delete Operations
 
 Delete Operations map to HTTP DELETE.
 
--   The `/v2/entities/<entity>` endpoint is used to delete an entity
--   The `/v2/entities/<entity>/attrs/<attribute>` endpoint is used to delete an
+-   The `/v2/entities/<entity>` endpoint can be used to delete an entity
+-   The `/v2/entities/<entity>/attrs/<attribute>` endpoint can be used to delete an
     attribute
 
 The response will be **204 - No Content** if the operation is successful or
-**404 - Not Found** error response if the operation fails
+**404 - Not Found** if the operation fails.
 
 ### Data Relationships
 
@@ -1060,10 +1061,10 @@ are left dangling once the entity has been deleted.
 Organizing a cascade of deletions is beyond the scope of this tutorial, but it
 would be possible using a batch delete request.
 
-### Delete a Data Entity
+### Delete an Entity
 
-This example deletes the Entity with `id=urn:ngsi-ld:Product:001` from the
-context
+This example deletes the entity with `id=urn:ngsi-ld:Product:001` from the
+context.
 
 #### :one::nine: Request:
 
@@ -1072,33 +1073,33 @@ curl -iX DELETE \
   --url 'http://localhost:1026/v2/entities/urn:ngsi-ld:Product:010'
 ```
 
-Entities be deleted by making a DELETE request to the `/v2/entities/<entity>`
+Entities can be deleted by making a DELETE request to the `/v2/entities/<entity>`
 endpoint.
 
 Subsequent requests using the same `id` will result in an error response since
 the entity no longer exists in the context.
 
-### Delete an Attribute from a Data Entity
+### Delete an Attribute from an Entity
 
-This example remove the `specialOffer` attribute from the entity with
-`id=urn:ngsi-ld:Product:010`
+This example removes the `specialOffer` attribute from the entity with
+`id=urn:ngsi-ld:Product:001`.
 
 #### :two::zero: Request:
 
 ```console
 curl -iX DELETE \
-  --url 'http://localhost:1026/v2/entities/urn:ngsi-ld:Product:010/attrs/specialOffer'
+  --url 'http://localhost:1026/v2/entities/urn:ngsi-ld:Product:001/attrs/specialOffer'
 ```
 
 Attributes can be deleted by making a DELETE request to the
 `/v2/entities/<entity>/attrs/<attribute>` endpoint.
 
-If the attribute does not exist in the context, the result in an error response.
+If the attribute does not exist in the context, the result will be an error response.
 
-### Batch Delete Multiple Data Entities
+### Batch Delete Multiple Entities
 
-This example uses the convenience batch processing endpoint to delete a series
-of available **Product** entities.
+This example uses the convenience batch processing endpoint to delete some
+**Product** entities.
 
 #### :two::one: Request:
 
@@ -1121,14 +1122,14 @@ curl -iX POST \
 
 Batch processing uses the `/v2/op/update` endpoint with a payload with two
 attributes - `actionType=delete` means we will delete something from the context
-and the `entities` attribute holds the `id` of the entities we wish to update.
+and the `entities` attribute holds the `id` of the entities we wish to delete.
 
-If any entity does not exist in the context, the result in an error response.
+If an entity does not exist in the context, the result will be an error response.
 
-### Batch Delete Multiple Attributes from a Data Entity
+### Batch Delete Multiple Attributes from an Entity
 
-This example uses the convenience batch processing endpoint to delete a series
-of attributes from an available **Product** entity.
+This example uses the convenience batch processing endpoint to delete some
+attributes from a **Product** entity.
 
 #### :two::two: Request:
 
@@ -1140,7 +1141,7 @@ curl -iX POST \
   "actionType":"delete",
   "entities":[
     {
-      "id":"urn:ngsi-ld:Product:010", "type":"Product",
+      "id":"urn:ngsi-ld:Product:003", "type":"Product",
       "price":{},
       "name": {}
     }
@@ -1150,7 +1151,7 @@ curl -iX POST \
 
 Batch processing uses the `/v2/op/update` endpoint with a payload with two
 attributes - `actionType=delete` means we will delete something from the context
-and the `entities` attribute holds an array of attributes we wish to update.
+and the `entities` attribute holds an array of attributes we wish to delete.
 
 If any attribute does not exist in the context, the result will be an error
 response.
@@ -1174,18 +1175,6 @@ curl -X GET \
     {
         "id": "urn:ngsi-ld:InventoryItem:001",
         "type": "InventoryItem"
-    },
-    {
-        "id": "urn:ngsi-ld:InventoryItem:004",
-        "type": "InventoryItem"
-    },
-    {
-        "id": "urn:ngsi-ld:InventoryItem:006",
-        "type": "InventoryItem"
-    },
-    {
-        "id": "urn:ngsi-ld:InventoryItem:401",
-        "type": "InventoryItem"
     }
 ]
 ```
@@ -1195,6 +1184,10 @@ curl -X GET \
 -   If the response lists a series of **InventoryItem** entities they should be
     deleted before the associated **Product** entity is removed from the
     context.
+
+Note that we deleted **Product** `urn:ngsi-ld:Product:001` earlier, so what we
+see above is actually a dangling reference, i.e. the returned **InventoryItem**
+references a **Product** that no longer exists. 
 
 # Next Steps
 


### PR DESCRIPTION
This PR's main purpose is to fix the cURL commands of a few out-of-date examples. For the rest there's a bunch of silly changes to get rid of typos and make the docs slightly clearer in some places.

Question. Since we changed some cURL commands, we should also update the Postman collection accordingly. Ditto for the docs. What's the best way of doing this? C&P?